### PR TITLE
Refactor curl function to be more generic

### DIFF
--- a/Lib/utils.php
+++ b/Lib/utils.php
@@ -4,17 +4,19 @@ App::uses('CakeLog', 'Log');
 
 class RcauthSourceUtils
 {
-// Wrapper for curl
 
   /**
+   * HttpCurlClient
+   *
    * @param $url      The URL used to address the request
    * @param $fields   List of query parameters in a key=>value array format
    * @param $error
    * @param $info
+   * @param array $options
    * @return bool|string
    * @throws Exception
    */
-  public static function do_curl($url, $fields, &$error, &$info)
+  public static function HttpCurlClient($url, $fields, &$error, &$info, $options = NULL)
   {
     //url-ify the data for the POST
     $fields_string = "";
@@ -27,18 +29,24 @@ class RcauthSourceUtils
 
     // set the url, number of POST vars, POST data
     // Content-type: application/x-www-form-urlencoded => is the default approach for post requests
-    curl_setopt($ch, CURLOPT_URL, $url);
-    curl_setopt($ch, CURLOPT_POST, count($fields));
-    curl_setopt($ch, CURLOPT_POSTFIELDS, $fields_string);
-    curl_setopt($ch, CURLOPT_HEADER, false);
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
-    curl_setopt($ch, CURLOPT_VERBOSE, true);
-    curl_setopt($ch, CURLOPT_TIMEOUT, 3000);
+    if(empty($options) || isset($options['curlType']) == 'POST') {
+      curl_setopt($ch, CURLOPT_URL, $url);
+      curl_setopt($ch, CURLOPT_POST, count($fields));
+      curl_setopt($ch, CURLOPT_POSTFIELDS, $fields_string);
+    }
+    else { //GET Request
+      curl_setopt($ch, CURLOPT_POST, FALSE);
+      curl_setopt($ch, CURLOPT_URL, $url.'?'.$fields_string);
+    }
+    curl_setopt($ch, CURLOPT_HEADER, !empty($options) && isset($options['header']) ? $options['header'] : FALSE);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, !empty($options) && isset($options['returnTransfer']) ? $options['returnTransfer'] : TRUE);
+    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, !empty($options) && isset($options['followLocation']) ? $options['followLocation'] : FALSE);
+    curl_setopt($ch, CURLOPT_VERBOSE, !empty($options) && isset($options['verbose']) ? $options['verbose'] : TRUE);
+    curl_setopt($ch, CURLOPT_TIMEOUT, !empty($options) && isset($options['timeout']) ? $options['timeout'] : 3000);
 
     // execute post
     $response = curl_exec($ch);
-    $status_code = "";
+    
     // fixme: Make curl throw an dnot return the errors
     $error = "";
     if (empty($response)) {
@@ -57,5 +65,3 @@ class RcauthSourceUtils
     return $response;
   }
 }
-
-?>

--- a/Model/RcauthSourceBackend.php
+++ b/Model/RcauthSourceBackend.php
@@ -95,7 +95,7 @@ class RcauthSourceBackend extends OrgIdentitySourceBackend {
     );
 
 
-    $response = RcauthSourceUtils::do_curl($this->mpOA2Server->getTokenEndpoint(),$params,$error, $info);
+    $response = RcauthSourceUtils::HttpCurlClient($this->mpOA2Server->getTokenEndpoint(),$params,$error, $info);
     if(!empty($info['http_code'])){
       // The request returned successfully. Dump data into an object, check their validity and return
       // data object from json decode
@@ -110,7 +110,7 @@ class RcauthSourceBackend extends OrgIdentitySourceBackend {
         return $data;
       }
     }elseif (!empty($error)){
-      $this->log('@exchangeCode:curl http post failed: msg => '.$error, LOG_DEBUG);
+      $this->log(__METHOD__ . '::curl http post failed: msg => '.$error, LOG_DEBUG);
       // There should be an error in the response
       throw new RuntimeException(_txt('er.rcauthsource.code',$error));
     }
@@ -164,19 +164,19 @@ class RcauthSourceBackend extends OrgIdentitySourceBackend {
     );
 
     // The request will return a json with the following format and fields
-    //  {
-    //     "sub":"025659b401b45793253dbe525111c8e54145569de85e544dd557ef6825d3814c@example.org",
-    //     "idp":"https://aai.example.org/proxy/saml2/idp/metadata.php",
-    //     "eduPersonTargetedID":"https://aai.example.org/proxy/saml2/idp/metadata.php!7c066f48d4b19621a3c5bd4c7afd5882b20ab30d",
-    //     "cert_subject_dn":"CN=John Doe yCKcijJUgi9e8Y4s,O=Example Org,OU=AAI,O=Example",
-    //     "idp_display_name":"AAI Example",
-    //     "name":"John Doe",
-    //     "eduPersonUniqueId":"025659b401b45793253dbe525111c8e54145569de85e544dd557ef6825d3814c@example.org",
-    //     "given_name":"John",
-    //     "family_name":"Doe",
-    //     "email":"jdoe@mail.com"
-    //  }
-    $response = RcauthSourceUtils::do_curl($this->mpOA2Server->getUserinfoEndpoint(),$options,$error, $info);
+    //	  {
+    //	  	   "sub":"025659b401b45793253dbe525111c8e54145569de85e544dd557ef6825d3814c@example.org",
+    //		   "idp":"https://aai.example.org/proxy/saml2/idp/metadata.php",
+    //		   "eduPersonTargetedID":"https://aai.example.org/proxy/saml2/idp/metadata.php!7c066f48d4b19621a3c5bd4c7afd5882b20ab30d",
+    //		   "cert_subject_dn":"CN=John Doe yCKcijJUgi9e8Y4s,O=Example Org,OU=AAI,O=Example",
+    //		   "idp_display_name":"AAI Example",
+    //		   "name":"John Doe",
+    //		   "eduPersonUniqueId":"025659b401b45793253dbe525111c8e54145569de85e544dd557ef6825d3814c@example.org",
+    //		   "given_name":"John",
+    //		   "family_name":"Doe",
+    //		   "email":"jdoe@mail.com"
+    //		}
+    $response = RcauthSourceUtils::HttpCurlClient($this->mpOA2Server->getUserinfoEndpoint(),$options,$error, $info);
 
 
     if( (int)$info['http_code'] >= 400
@@ -243,7 +243,7 @@ class RcauthSourceBackend extends OrgIdentitySourceBackend {
    * Convert a search result into an Org Identity.
    *
    * @since  COmanage Registry v3.1.0
-   * @param  Array $result RCAUTH Search Result. This is an object not an array
+   * @param  Object $result RCAUTH Search Result. This is an object not an array
    * @return Array Org Identity and related models, in the usual format
    */
   protected function resultToOrgIdentity($result) {


### PR DESCRIPTION
Put $options variable to make function more generic.
$options['type']: GET or POST
$options['header']: TRUE or FALSE (default: FALSE)
$options['returnTransfer']: TRUE or FALSE (default: TRUE)
$options['followLocation']: TRUE or FALSE (default: FALSE)
$options['verbose']: TRUE or FALSE (default: TRUE)
$options['timeout']: integer (default: 3000)